### PR TITLE
Quick Patch for HA 0.106

### DIFF
--- a/www/floorplan/lib/floorplan.js
+++ b/www/floorplan/lib/floorplan.js
@@ -58,7 +58,7 @@
             return Promise.resolve();
           }
 
-          this.config = config;
+          this.config = Object.assign({}, config);
 
           return this.loadLibraries()
             .then(() => {


### PR DESCRIPTION
This is a patch that creates a copy of the config object that is now frozen in HA 0.106 and can't be modified directly.  Addresses Issue #20 