### PR TITLE
Added option to don't set the entity_id

### DIFF
--- a/www/floorplan/lib/floorplan.js
+++ b/www/floorplan/lib/floorplan.js
@@ -1588,7 +1588,7 @@
       const actionService = this.getActionService(action, entityId, svgElement);
       const actionData = this.getActionData(action, entityId, svgElement);
 
-      if (!actionData.entity_id && entityId) {
+      if (!actionData.entity_id && entityId && !action.no_entity_id) {
         actionData.entity_id = entityId;
       }
 


### PR DESCRIPTION
 Added an option named `no_entity_id` which prevents the entity_id to be set.

This is usefull for actions which don't accept an entity_id while you do want an element bound to that entity.
Examples of services which don't use an entity_id are
 - hue.hue_activate_scene 
 - variable.set_variable