### PR TITLE
Long click

### DIFF
--- a/www/floorplan/floorplan-card.js
+++ b/www/floorplan/floorplan-card.js
@@ -195,7 +195,7 @@ class FloorplanCard extends HTMLElement {
     return new Promise((resolve, reject) => {
       let script = document.createElement('script');
       script.async = false;
-      script.src = scriptUrl; //useCache ? scriptUrl : this.cacheBuster(scriptUrl);
+      script.src = useCace ? scriptUrl : this.cacheBuster(scriptUrl);
       script.onload = () => resolve();
       script.onerror = (err) => reject(new URIError(`${err.target.src}`));
       this.appendChild(script);

--- a/www/floorplan/floorplan-card.js
+++ b/www/floorplan/floorplan-card.js
@@ -195,7 +195,7 @@ class FloorplanCard extends HTMLElement {
     return new Promise((resolve, reject) => {
       let script = document.createElement('script');
       script.async = false;
-      script.src = useCace ? scriptUrl : this.cacheBuster(scriptUrl);
+      script.src = useCache ? scriptUrl : this.cacheBuster(scriptUrl);
       script.onload = () => resolve();
       script.onerror = (err) => reject(new URIError(`${err.target.src}`));
       this.appendChild(script);

--- a/www/floorplan/floorplan-card.js
+++ b/www/floorplan/floorplan-card.js
@@ -40,6 +40,7 @@ class FloorplanCard extends HTMLElement {
     promises.push(this.loadScript(`/local/floorplan/lib/floorplan.js?v=${this.version}`, true));
     promises.push(this.loadScript('/local/floorplan/lib/yaml.min.js', true));
     promises.push(this.loadScript('/local/floorplan/lib/jquery-3.4.1.min.js', true));
+    promises.push(this.loadScript('/local/floorplan/lib/jquery.longclick-1.0.js', true));
 
     return Promise.all(promises)
       .then(() => {
@@ -193,8 +194,8 @@ class FloorplanCard extends HTMLElement {
   loadScript(scriptUrl, useCache) {
     return new Promise((resolve, reject) => {
       let script = document.createElement('script');
-      script.async = true;
-      script.src = useCache ? scriptUrl : this.cacheBuster(scriptUrl);
+      script.async = false;
+      script.src = scriptUrl; //useCache ? scriptUrl : this.cacheBuster(scriptUrl);
       script.onload = () => resolve();
       script.onerror = (err) => reject(new URIError(`${err.target.src}`));
       this.appendChild(script);

--- a/www/floorplan/ha-floorplan.html
+++ b/www/floorplan/ha-floorplan.html
@@ -1,5 +1,6 @@
-<script src="./lib/jquery-3.4.1.min.js"></script>
-<script src="./lib/yaml.min.js"></script>
+<script type="javascript" src="./lib/jquery-3.4.1.min.js"></script>
+<script type="javascript" src="./lib/yaml.min.js"></script>
+<script type="javascript" src="./lib/jquery.longclick-1.0.js"></script>
 
 <dom-module id="ha-floorplan">
 

--- a/www/floorplan/lib/floorplan.js
+++ b/www/floorplan/lib/floorplan.js
@@ -221,7 +221,13 @@
       let imageUrl = '';
 
       if (typeof config.image === 'string') {
-        imageUrl = config.image;
+        // device detection
+        if(/(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|ipad|iris|kindle|Android|Silk|lge |maemo|midp|mmp|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows (ce|phone)|xda|xiino/i.test(navigator.userAgent) 
+           || /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(navigator.userAgent.substr(0,4))) { 
+           imageUrl = config.image_mobile;
+        } else {
+          imageUrl = config.image;
+        }
       }
       else {
         if (config.image.sizes) {
@@ -352,11 +358,12 @@
             svgElement = this.createImageElement(svgElementInfo.originalSvgElement);
 
             $(svgElement).append(document.createElementNS('http://www.w3.org/2000/svg', 'title'))
-              .off('click')
-              .on('click', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
+              .mayTriggerLongClicks().off('shortClick')
+              .mayTriggerLongClicks().off('longClick')
+              .mayTriggerLongClicks().on('shortClick', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
+              .mayTriggerLongClicks().on('longClick', this.onEntityLongClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
               .css('cursor', 'pointer')
               .addClass('ha-entity');
-
             svgElementInfo.svgElement = this.replaceElement(svgElementInfo.svgElement, svgElement);
           }
 
@@ -392,11 +399,12 @@
             .attr('y', svgElementInfo.originalBBox.y);
 
           $(svgElement).find('*').append(document.createElementNS('http://www.w3.org/2000/svg', 'title'))
-            .off('click')
-            .on('click', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
+            .mayTriggerLongClicks().off('shortClick')
+            .mayTriggerLongClicks().off('longClick')
+            .mayTriggerLongClicks().on('shortClick', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
+            .mayTriggerLongClicks().on('longClick', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: rule }))
             .css('cursor', 'pointer')
             .addClass('ha-entity');
-
           svgElementInfo.svgElement = this.replaceElement(svgElementInfo.svgElement, svgElement);
 
           return Promise.resolve(svgElement);
@@ -407,10 +415,10 @@
       const $parent = $(prevousSvgElement).parent();
 
       $(prevousSvgElement).find('*')
-        .off('click');
+        .mayTriggerLongClicks().off('shortClick');
 
       $(prevousSvgElement)
-        .off('click')
+        .mayTriggerLongClicks().off('shortClick')
         .remove();
 
       $parent.append(svgElement);
@@ -627,9 +635,14 @@
           $svgElement.append(document.createElementNS('http://www.w3.org/2000/svg', 'title'));
 
           if (ruleInfo.rule.action || (ruleInfo.rule.more_info !== false)) {
-            $svgElement.off('click').on('click', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: ruleInfo.rule }));
+            $svgElement.mayTriggerLongClicks().on('shortClick', this.onEntityClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: ruleInfo.rule }));
             $svgElement.css('cursor', 'pointer');
           }
+          if (ruleInfo.rule.long_click) {
+            $svgElement.mayTriggerLongClicks().on('longClick', this.onEntityLongClick.bind({ instance: this, svgElementInfo: svgElementInfo, entityId: entityId, rule: ruleInfo.rule }));
+            $svgElement.css('cursor', 'pointer');
+          }
+
           $svgElement.addClass('ha-entity');
 
           /*
@@ -725,8 +738,13 @@
 
           const $svgElement = $(svgElementInfo.svgElement);
 
-          $svgElement.off('click').on('click', this.onElementClick.bind({ instance: this, svgElementInfo: svgElementInfo, elementId: elementId, rule: rule }));
+          $svgElement.mayTriggerLongClicks().off('shortClick');
+          $svgElement.mayTriggerLongClicks().on('shortClick', this.onElementClick.bind({ instance: this, svgElementInfo: svgElementInfo, elementId: elementId, rule: rule }));
           $svgElement.css('cursor', 'pointer');
+          if (ruleInfo.rule.long_click) {
+            $svgElement.mayTriggerLongClicks().off('longClick');
+            $svgElement.mayTriggerLongClicks().on('longClick', this.onElementLongClick.bind({ instance: this, svgElementInfo: svgElementInfo, elementId: elementId, rule: rule }));
+          }
 
           /*
           if ($svgElement.is('text') && ($svgElement[0].id === elementId)) {
@@ -831,7 +849,6 @@
                 .attr('width', $(svgElement).attr('width'))[0];
                 */
     }
-
     addClasses(entityId, svgElement, classes, propagate) {
       if (!classes || !classes.length) return;
 
@@ -1426,21 +1443,42 @@
 
     onElementClick(e) {
       e.stopPropagation();
+      e.preventDefault();
+
       this.instance.onActionClick(this.svgElementInfo, this.elementId, this.elementId, this.rule);
+    }
+
+    onElementLongClick(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      this.instance.onActionClick(this.svgElementInfo, this.elementId, this.elementId, null);
     }
 
     onEntityClick(e) {
       e.stopPropagation();
+      e.preventDefault();
       this.instance.onActionClick(this.svgElementInfo, this.entityId, this.elementId, this.rule);
     }
+    
+    longClick(e){
+      this.instance.onActionClick(this.svgElementInfo, this.entityId, this.elementId, null);
+    }    
+
+    onEntityLongClick(e) {
+      e.stopPropagation();
+      e.preventDefault();
+      setTimeout(this.instance.longClick.bind(this, e), 300);
+
+    }
+
 
     onActionClick(svgElementInfo, entityId, elementId, rule) {
       let entityInfo = this.entityInfos[entityId];
-      const actionRuleInfo = entityInfo && entityInfo.ruleInfos.find(ruleInfo => ruleInfo.rule.action);
-      const actionRule = rule.action ? rule : (actionRuleInfo ? actionRuleInfo.rule : undefined);
+      const actionRuleInfo = rule !==  null && (entityInfo && entityInfo.ruleInfos.find(ruleInfo => ruleInfo.rule.action)) 	;
+      const actionRule = (rule !== null  && rule.action) ? rule : (actionRuleInfo ? actionRuleInfo.rule : undefined);
 
       if (!rule || !actionRule) {
-        if (entityId && (rule.more_info !== false)) {
+        if (rule == null || (entityId && (rule.more_info !== false))) {
           this.openMoreInfo(entityId);
         }
         return;

--- a/www/floorplan/lib/jquery.longclick-1.0.js
+++ b/www/floorplan/lib/jquery.longclick-1.0.js
@@ -1,0 +1,49 @@
+//function to enable long clicks in floorplan
+//credit to @tknp for the code enclosed
+
+( function( $) {
+
+    // -- variables --
+    var  defaults = {
+      NS: 'jquery.longclick-',
+      delay: 400
+    };
+  
+  
+    // -- function --
+    $.fn.mayTriggerLongClicks = function( options) {
+      // alter settings according to options
+      var settings = $.extend( defaults, options);
+      // define long click based on mousedown and mouseup
+      var timer;
+      var haveLongClick;
+      return $( this).on( 'mousedown tapstart touchstart', function(evt) {
+        haveLongClick = false;
+        timer = setTimeout( function( elm) {
+                  haveLongClick = true;
+         //         $( elm ).off('click');
+           //         evt.preventDefault();
+           //       evt.stopImmediatePropagation();
+
+                  $( elm).trigger( 'longClick');
+               }, settings.delay, this);
+         } 
+      )
+     .on( 'click mouseup tapend touchend', function(evt) {
+        clearTimeout( timer);
+            evt.stopImmediatePropagation();
+       
+             evt.preventDefault();
+          //  evt.stopPropagation();
+
+        if( haveLongClick) {
+         // have already triggered long click
+        } else {
+           // return shortClick, shortMouseup etc
+           $(this).trigger( 'short' + evt.type[0].toUpperCase() + evt.type.slice(1));
+        } 
+} 
+     );.
+    }  // $.fn.mayTriggerLongClicks
+    
+  } )( jQuery);

--- a/www/floorplan/lib/jquery.longclick-1.0.js
+++ b/www/floorplan/lib/jquery.longclick-1.0.js
@@ -21,29 +21,33 @@
         haveLongClick = false;
         timer = setTimeout( function( elm) {
                   haveLongClick = true;
-         //         $( elm ).off('click');
-           //         evt.preventDefault();
-           //       evt.stopImmediatePropagation();
-
                   $( elm).trigger( 'longClick');
                }, settings.delay, this);
          } 
       )
      .on( 'click mouseup tapend touchend', function(evt) {
         clearTimeout( timer);
-            evt.stopImmediatePropagation();
-       
-             evt.preventDefault();
-          //  evt.stopPropagation();
 
         if( haveLongClick) {
          // have already triggered long click
         } else {
-           // return shortClick, shortMouseup etc
+           // trigger shortClick, shortMouseup etc
            $(this).trigger( 'short' + evt.type[0].toUpperCase() + evt.type.slice(1));
         } 
 } 
-     );.
+     ).
+     on( 'tap touch mouseup tapend touchend', function( evt) {
+           if (haveLongClick) {
+             evt.preventDefault();
+             evt.stopImmediatePropagation();
+           }
+      } 
+     )
+     . on( 'click', function( evt) {
+             evt.preventDefault();
+             evt.stopImmediatePropagation();
+      }
+    );
     }  // $.fn.mayTriggerLongClicks
     
   } )( jQuery);


### PR DESCRIPTION
Added:

1. Long click functionality, launch separate action on long press.
2. Use seperate svg for mobile
3. Preload cards and rows to workaround issues introduced by 107 where custom cards like floorplan do not correctly preload cards or row. e.g. Customer element hui-gauge not found errors.

(I know we should be probably be moving to PictureElement floorplan, just easier to tweak this rather than redo my visual layout : )).

Config for these:

```
   - config:
          image: /local/floorplan/examples/simple/429.svg?v=5
          image_mobile: /local/floorplan/examples/simple/429_transformed.svg?v=5
          preload_cards:
            - map
            - gauge
          preload_rows:
            - lock-entity-row
          rules:
            - action: null
              entities:
                - vacuum.chop_chop
              long_click:
                data:
                  card:
                    entities:
                      - entity: device_tracker.automower_h_182302002_182040696
                    hours_to_show: 12
                    type: map
                  deviceID: this
                  style:
                    '--more-info-header-background': 'rgba(255, 159, 9, 1)'
                  title: Chop chop
                service: browser_mod.popup
```
